### PR TITLE
Updating rpenv to latest and Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ A collection of internal homebrew formulae for use within RentPath.
 ## Updating Formulae
 See the info at https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Formula-Cookbook.md
 
-To generate a SHA1 checksum on OS X, run `openssl sha1 <path to file>`
+To generate a SHA256 checksum on OS X, run `shasum -a 256 <path to file>`

--- a/rpenv.rb
+++ b/rpenv.rb
@@ -4,8 +4,8 @@ class Rpenv < Formula
   PACKAGE = "github.com/rentpath/rpenv"
 
   homepage "https://#{PACKAGE}"
-  url "https://#{PACKAGE}/archive/v2.0.0.tar.gz"
-  sha1 "bb81687792af1ac30c45a12d4725c2ba731f2b32"
+  url "https://#{PACKAGE}/archive/v2.0.1.tar.gz"
+  sha256 "38c2f5f5e005b99a9fa47b022b6d991c01fc4bbc1d17cc76477ce734a7e87883"
   head "https://#{PACKAGE}.git"
 
   depends_on "go" => :build

--- a/varnish2.rb
+++ b/varnish2.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Varnish2 < Formula
   homepage 'http://www.varnish-cache.org/'
   url 'http://repo.varnish-cache.org/source/varnish-2.1.5.tar.gz'
-  sha1 '5c413ee7c4267d9fd4713fbff059d1be5fbba60f'
+  sha256 '2d8049be14ada035d0e3a54c2b519143af40d03d917763cf72d53d8188e5ef83'
 
   depends_on 'pkg-config' => :build
   depends_on 'pcre'


### PR DESCRIPTION
- updating formulas to use `sha256`, warnings from `homebrew`
- updating rpenv to latest 2.0.1
- updating README and how to generate sha256