### PR TITLE
updates formula to install project vendor depends

### DIFF
--- a/rpenv.rb
+++ b/rpenv.rb
@@ -11,7 +11,7 @@ class Rpenv < Formula
   depends_on "go" => :build
 
   def install
-    (buildpath/"src/#{PACKAGE}").install Dir["./*.go"]
+    (buildpath/"src/#{PACKAGE}").install Dir["./*"]
 
     ENV["GOPATH"] = buildpath
 


### PR DESCRIPTION
[Card](https://rentpath.leankit.com/card/607001126)

Fixes where we were only moving over *.go files in the brew formula.  Now that we have external vendored dependencies we have to move over more than that to successfully compile the binary.